### PR TITLE
refer to intended class ivar instead of local var

### DIFF
--- a/GorHill/FineDiff/FineDiffOps.php
+++ b/GorHill/FineDiff/FineDiffOps.php
@@ -48,14 +48,13 @@ class FineDiffOps {
             $encoding = mb_internal_encoding();
         }
         if ( $opcode === 'c' ) {
-            $edits[] = new FineDiffCopyOp($from_len);
+            $this->edits[] = new FineDiffCopyOp($from_len);
         }
         else if ( $opcode === 'd' ) {
-            $edits[] = new FineDiffDeleteOp($from_len);
+            $this->edits[] = new FineDiffDeleteOp($from_len);
         }
         else /* if ( $opcode === 'i' ) */ {
-            $edits[] = new FineDiffInsertOp(mb_substr($from, $from_offset, $from_len, $encoding), $encoding);
+            $this->edits[] = new FineDiffInsertOp(mb_substr($from, $from_offset, $from_len, $encoding), $encoding);
         }
     }
-    public $edits = array();
 }


### PR DESCRIPTION
Since the operations were being added to a local `edits` variable, nothing was ever getting saved in the ivar.