### PR TITLE
Fix: Passing null to parameter #3 is deprecated

### DIFF
--- a/GorHill/FineDiff/FineDiff.php
+++ b/GorHill/FineDiff/FineDiff.php
@@ -593,7 +593,7 @@ class FineDiff {
         }
         $fragments = array();
         $offset = 0;
-        $split = preg_split('/([' . preg_quote($delimiters, '/') . ']+)/u', $text, null, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $split = preg_split('/([' . preg_quote($delimiters, '/') . ']+)/u', $text, 0, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
         foreach($split as $m) {
             $fragments[$offset] = $m;
             $offset += mb_strlen($m, $encoding);


### PR DESCRIPTION
Fix warning with PHP 8.1: "Deprecated: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in GorHill/FineDiff/FineDiff.php on line 596".